### PR TITLE
Add an option to disable propagation

### DIFF
--- a/opentracing-apache-httpclient/src/main/java/io/opentracing/contrib/apache/http/client/TracingHttpClientBuilder.java
+++ b/opentracing-apache-httpclient/src/main/java/io/opentracing/contrib/apache/http/client/TracingHttpClientBuilder.java
@@ -18,9 +18,9 @@ public class TracingHttpClientBuilder extends HttpClientBuilder {
 
     private final RedirectStrategy redirectStrategy;
     private final boolean redirectHandlingDisabled;
-
     private Tracer tracer;
     private List<ApacheClientSpanDecorator> spanDecorators;
+    private boolean injectDisabled;
 
     /**
      * When using this constructor tracer should be registered via
@@ -86,9 +86,14 @@ public class TracingHttpClientBuilder extends HttpClientBuilder {
         return this;
     }
 
+    public TracingHttpClientBuilder disableInjection() {
+        this.injectDisabled = true;
+        return this;
+    }
+
     @Override
     protected ClientExecChain decorateProtocolExec(final ClientExecChain requestExecutor) {
         return new TracingClientExec(requestExecutor, redirectStrategy,
-                redirectHandlingDisabled, tracer, spanDecorators);
+                redirectHandlingDisabled, injectDisabled, tracer, spanDecorators);
     }
 }

--- a/opentracing-apache-httpclient/src/test/java/io/opentracing/contrib/apache/http/client/TracingHttpClientBuilderTest.java
+++ b/opentracing-apache-httpclient/src/test/java/io/opentracing/contrib/apache/http/client/TracingHttpClientBuilderTest.java
@@ -277,6 +277,24 @@ public class TracingHttpClientBuilderTest extends LocalServerTestBase {
     }
 
     @Test
+    public void testDisablePropagation() throws IOException {
+        {
+            HttpClient client = ((TracingHttpClientBuilder)clientBuilder).disableInjection().build();
+            client.execute(new HttpGet(serverUrl(RedirectHandler.MAPPING)));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(3, mockSpans.size());
+
+        // the last one is for redirect
+        MockSpan mockSpan = mockSpans.get(1);
+        Assert.assertEquals(PropagationHandler.lastRequest.getFirstHeader("traceId"), null);
+        Assert.assertEquals(PropagationHandler.lastRequest.getFirstHeader("spanId"), null);
+
+        assertLocalSpan(mockSpans.get(2));
+    }
+
+    @Test
     public void testUnknownHostException() throws IOException {
         CloseableHttpClient client = clientBuilder.build();
 


### PR DESCRIPTION
For a recent project my service is communicating to a third party instead of an internal micro service. I don't want to expose the trace and span id to this third party.

This PR adds an option to the client builder to disable the injection of the span and scope into outgoing requests