### PR TITLE
Fix IllegalStateException "Finishing already finished span" when HttpRequestRetryHandler is used

### DIFF
--- a/opentracing-apache-httpclient/src/main/java/io/opentracing/contrib/apache/http/client/ApacheClientSpanDecorator.java
+++ b/opentracing-apache-httpclient/src/main/java/io/opentracing/contrib/apache/http/client/ApacheClientSpanDecorator.java
@@ -61,7 +61,7 @@ public interface ApacheClientSpanDecorator {
 
             Tags.HTTP_METHOD.set(span, request.getRequestLine().getMethod());
 
-            if (uri != null) {
+            if (uri != null && uri.isAbsolute()) {
                 Tags.HTTP_URL.set(span, uri.toString());
                 Tags.PEER_HOSTNAME.set(span, uri.getHost());
                 int port = uri.getPort();


### PR DESCRIPTION
`HttpClientBuilder`, by default, inserts `RetryExec` in the exec chain. This handler catches IOExceptions, and retries the request if possible. `TracingClientExec.execute`, which runs before `RetryExec.execute`, closes the span on failure. If the request is retried, then the existing (closed span) is re-used, which afterwards results in an IllegalStateException with the "Finishing already finished span" message. The unit test below reproduces that error.

This PR should fix the issue.